### PR TITLE
type bugs

### DIFF
--- a/com/precisely/apis/model/candidate_range.py
+++ b/com/precisely/apis/model/candidate_range.py
@@ -106,7 +106,7 @@ class CandidateRange(ModelNormal):
             'side': (str,),  # noqa: E501
             'odd_even_indicator': (str,),  # noqa: E501
             'units': ([CandidateRangeUnit],),  # noqa: E501
-            'custom_values': ({str: ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},)},),  # noqa: E501
+            'custom_values': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},),  # noqa: E501
         }
 
     @cached_property

--- a/com/precisely/apis/model/candidate_range_unit.py
+++ b/com/precisely/apis/model/candidate_range_unit.py
@@ -85,7 +85,7 @@ class CandidateRangeUnit(ModelNormal):
             'unit_type': (str,),  # noqa: E501
             'high_unit_value': (str,),  # noqa: E501
             'low_unit_value': (str,),  # noqa: E501
-            'custom_values': ({str: ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},)},),  # noqa: E501
+            'custom_values': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},),  # noqa: E501
         }
 
     @cached_property

--- a/com/precisely/apis/model/geocode_address.py
+++ b/com/precisely/apis/model/geocode_address.py
@@ -96,7 +96,7 @@ class GeocodeAddress(ModelNormal):
             'street_name': (str,),  # noqa: E501
             'unit_type': (str,),  # noqa: E501
             'unit_value': (str,),  # noqa: E501
-            'custom_fields': ({str: ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},)},),  # noqa: E501
+            'custom_fields': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},),  # noqa: E501
         }
 
     @cached_property


### PR DESCRIPTION
In the process of trying to use the [Geocode Request ](https://github.com/PreciselyData/PreciselyAPIsSDK-Python/blob/main/docs/GeocodeServiceApi.md)(both GET and POST) I ran into type errors because the data returned by the  Precisely API failed the type checks you have in your client library. 

This pull request fixes the three bugs I ran into with those requests (which was any request with data other than your default address data).